### PR TITLE
Remove static fallback from paid combo

### DIFF
--- a/services/paid_combo.py
+++ b/services/paid_combo.py
@@ -9,11 +9,12 @@
 # services/paid_combo.py
 from typing import List
 from .models import Movie
-from . import paid_dynamic, paid_static
+from . import paid_dynamic
+
 
 def search(query: str, max_results: int = 20, country: str = "FR") -> List[Movie]:
-    """Combine JustWatch (réel) puis fallback liens de recherche si rien n'est trouvé."""
+    """Return paid offers from the dynamic provider only."""
     dyn = paid_dynamic.search(query, max_results=max_results, country=country)
     if dyn:
         return dyn[:max_results]
-    return paid_static.search(query, max_results=max_results, country=country)
+    return []


### PR DESCRIPTION
## Summary
- rely solely on dynamic provider in `paid_combo.search`
- drop `paid_static` fallback when no paid offers

## Testing
- `pytest`
- `python -m py_compile services/paid_combo.py`


------
https://chatgpt.com/codex/tasks/task_e_68aea3e159088326ad52c49e769a108c