### PR TITLE
Restrict JustWatch offers to purchase or rent

### DIFF
--- a/services/paid_dynamic.py
+++ b/services/paid_dynamic.py
@@ -71,7 +71,11 @@ def search(query: str, max_results: int = 20, country: str = "FR") -> List[Movie
             except Exception:
                 offers = []
 
-        offers = [o for o in (offers or []) if o.get("country") == country]
+        offers = [
+            o
+            for o in (offers or [])
+            if o.get("country") == country and o.get("monetization_type") in {"buy", "rent"}
+        ]
         if not offers:
             continue
 
@@ -95,7 +99,7 @@ def search(query: str, max_results: int = 20, country: str = "FR") -> List[Movie
                 year=year,
                 description=f"Disponible sur {prov_name} – {mono}",
                 stream_url=url,
-                source=f"{prov_name} (payant)",
+                source=f"{prov_name} ({mono})",
                 extra={"monetization": mono, "provider_id": pid},
             ))
             if len(out) >= max_results:


### PR DESCRIPTION
## Summary
- Only keep JustWatch offers that allow buying or renting and label the source accordingly.

## Testing
- `python -m py_compile services/paid_dynamic.py`
- `python - <<'PY'
from services import paid_dynamic
for title in ['Inception', 'Matrix', 'Avatar']:
    results = paid_dynamic.search(title)
    print(title, results)

print('\nSimulated offers filtering:')
offers = [
    {'provider_id':1, 'monetization_type':'flatrate', 'country':'FR'},
    {'provider_id':1, 'monetization_type':'buy', 'country':'FR'},
    {'provider_id':1, 'monetization_type':'rent', 'country':'FR'},
    {'provider_id':2, 'monetization_type':'ads', 'country':'FR'},
    {'provider_id':2, 'monetization_type':'buy', 'country':'FR'}
]
filtered = [o for o in offers if o.get('country')=='FR' and o.get('monetization_type') in {'buy','rent'}]
print(filtered)
PY` *(fails: JustWatch library not installed; simulated filter demonstrates behavior)*

------
https://chatgpt.com/codex/tasks/task_e_68aea5e67e5c8326a4b37cd48b65005a