### PR TITLE
Handle JustWatch API domain and HTTP errors

### DIFF
--- a/services/paid_dynamic.py
+++ b/services/paid_dynamic.py
@@ -8,11 +8,15 @@
 
 from typing import List, Dict, Optional, Set
 from .models import Movie
+import logging
+import requests
 
 try:
     from justwatch import JustWatch
 except Exception:
     JustWatch = None
+
+logger = logging.getLogger(__name__)
 
 MONETIZATION_PRIORITIES = ["buy", "rent", "flatrate", "ads", "free"]
 
@@ -42,9 +46,12 @@ def search(query: str, max_results: int = 20, country: str = "FR") -> List[Movie
     if not JustWatch:
         return []
 
-    jw = JustWatch(country=country)
+    jw = JustWatch(country=country, api_domain="https://apis.justwatch.com")
     try:
         data = jw.search_for_item(query=query, content_types=["movie"])
+    except requests.exceptions.HTTPError as err:
+        logger.error("JustWatch HTTP error: %s", err)
+        return []
     except Exception:
         return []
 


### PR DESCRIPTION
## Summary
- Initialize JustWatch with the current API domain
- Catch and log JustWatch HTTP errors to avoid crashes

## Testing
- ⚠️ `python - <<'PY'
from services import paid_dynamic
movies = paid_dynamic.search('Inception')
print(movies)
PY` (missing `requests` dependency)
- ⚠️ `pip install -r requirements.txt` (proxy blocked, could not install dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68aeec96a4cc83269a57c53b66713020