### PR TITLE
Add optional subscription offers to search

### DIFF
--- a/services/paid_combo.py
+++ b/services/paid_combo.py
@@ -12,9 +12,19 @@ from .models import Movie
 from . import paid_dynamic
 
 
-def search(query: str, max_results: int = 20, country: str = "FR") -> List[Movie]:
+def search(
+    query: str,
+    max_results: int = 20,
+    country: str = "FR",
+    include_subscriptions: bool = False,
+) -> List[Movie]:
     """Return paid offers from the dynamic provider only."""
-    dyn = paid_dynamic.search(query, max_results=max_results, country=country)
+    dyn = paid_dynamic.search(
+        query,
+        max_results=max_results,
+        country=country,
+        include_subscriptions=include_subscriptions,
+    )
     if dyn:
         return dyn[:max_results]
     return []

--- a/services/paid_dynamic.py
+++ b/services/paid_dynamic.py
@@ -42,7 +42,12 @@ def _best_offer_per_provider(offers: List[Dict]) -> Dict[int, Dict]:
 def _label_monetization(m: Optional[str]) -> str:
     return {"buy":"achat","rent":"location","flatrate":"abonnement","ads":"avec pub","free":"gratuit"}.get((m or "").lower(), m or "")
 
-def search(query: str, max_results: int = 20, country: str = "FR") -> List[Movie]:
+def search(
+    query: str,
+    max_results: int = 20,
+    country: str = "FR",
+    include_subscriptions: bool = False,
+) -> List[Movie]:
     if not JustWatch:
         return []
 
@@ -78,10 +83,11 @@ def search(query: str, max_results: int = 20, country: str = "FR") -> List[Movie
             except Exception:
                 offers = []
 
+        allowed = {"buy", "rent"} | ({"flatrate"} if include_subscriptions else set())
         offers = [
             o
             for o in (offers or [])
-            if o.get("country") == country and o.get("monetization_type") in {"buy", "rent"}
+            if o.get("country") == country and o.get("monetization_type") in allowed
         ]
         if not offers:
             continue

--- a/services/search.py
+++ b/services/search.py
@@ -28,6 +28,7 @@ def run_search(
     enrich_tmdb: bool = True,
     mode: str = "films",
     country: str = "FR",   # pays fixé ici
+    include_subscriptions: bool = False,
 ) -> Dict[str, List[Movie]]:
     order = order or DEFAULT_ORDER
     results: Dict[str, List[Movie]] = {}
@@ -46,7 +47,7 @@ def run_search(
             if k == "archive":
                 futures[ex.submit(PROVIDERS[k], query, max_results, mode)] = k
             elif k == "paid":
-                futures[ex.submit(PROVIDERS[k], query, max_results, country)] = k
+                futures[ex.submit(PROVIDERS[k], query, max_results, country, include_subscriptions)] = k
             else:
                 futures[ex.submit(PROVIDERS[k], query, max_results)] = k
 


### PR DESCRIPTION
## Summary
- add sidebar checkbox to include subscription offers
- propagate include_subscriptions flag through search services
- filter JustWatch results to optionally include flatrate offers

## Testing
- `python -m py_compile app.py services/search.py services/paid_combo.py services/paid_dynamic.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af347b6668832695098989e8828216