### PR TITLE
Update JustWatch API domain

### DIFF
--- a/services/paid_dynamic.py
+++ b/services/paid_dynamic.py
@@ -51,7 +51,7 @@ def search(
     if not JustWatch:
         return []
 
-    jw = JustWatch(country=country, api_domain="https://apis.justwatch.com")
+    jw = JustWatch(country=country, api_domain="https://apiv2.justwatch.com")
     try:
         data = jw.search_for_item(query=query, content_types=["movie"])
     except requests.exceptions.HTTPError as err:


### PR DESCRIPTION
## Summary
- use `apiv2.justwatch.com` when initializing `JustWatch`

## Testing
- `pip install --upgrade justwatch` *(failed: Tunnel connection failed: 403 Forbidden)*
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68af395d77b88326afe6233e4bb4d58f