### PR TITLE
Handle JustWatch HTTP errors in paid dynamic search

### DIFF
--- a/services/paid_dynamic.py
+++ b/services/paid_dynamic.py
@@ -54,8 +54,8 @@ def search(
     jw = JustWatch(country=country, api_domain="https://apiv2.justwatch.com")
     try:
         data = jw.search_for_item(query=query, content_types=["movie"])
-    except requests.exceptions.HTTPError as err:
-        logger.error("JustWatch HTTP error: %s", err)
+    except requests.HTTPError as err:
+        logger.exception("JustWatch HTTP error during search: %s", err)
         return []
     except Exception:
         return []
@@ -80,6 +80,9 @@ def search(
                 details = jw.get_title(content_type="movie", title_id=it.get("id"), language="fr")
                 offers = details.get("offers", [])
                 full_path = details.get("full_path", full_path)
+            except requests.HTTPError as err:
+                logger.exception("JustWatch HTTP error during title fetch: %s", err)
+                return []
             except Exception:
                 offers = []
 


### PR DESCRIPTION
## Summary
- log and handle JustWatch HTTP errors for item search
- log and handle JustWatch HTTP errors when fetching title details

## Testing
- `python -m py_compile services/paid_dynamic.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af3a4a42148326acdc31ed1d82cd88