### PR TITLE
Integrate paid store lookups and aggregate offers

### DIFF
--- a/services/paid_amazon.py
+++ b/services/paid_amazon.py
@@ -1,0 +1,28 @@
+############################
+# Paid Amazon              #
+#                          #
+# Last update : 2025/08/25 #
+############################
+
+import requests
+from typing import List
+from .models import Movie
+
+
+def search(query: str, max_results: int = 1, country: str = "FR") -> List[Movie]:
+    """Return an Amazon/Prime Video search link.
+
+    Amazon does not provide a simple unauthenticated API for Prime Video,
+    so we return a search page URL as a fallback.
+    """
+    q = requests.utils.quote(query)
+    domain = "www.primevideo.com"
+    url = f"https://{domain}/search?phrase={q}"
+    return [
+        Movie(
+            title=f"→ Prime Video : {query}",
+            description="Recherche Prime Video (achat/location)",
+            stream_url=url,
+            source="Amazon Prime Video",
+        )
+    ]

--- a/services/paid_google_play.py
+++ b/services/paid_google_play.py
@@ -1,0 +1,28 @@
+############################
+# Paid Google Play         #
+#                          #
+# Last update : 2025/08/25 #
+############################
+
+import requests
+from typing import List
+from .models import Movie
+
+
+def search(query: str, max_results: int = 1, country: str = "FR") -> List[Movie]:
+    """Return a Google Play Movies search link for the query.
+
+    Google does not expose a public movies API without authentication.
+    We therefore provide a direct search URL so the user can
+    complete the purchase on Google Play manually.
+    """
+    q = requests.utils.quote(query)
+    url = f"https://play.google.com/store/search?c=movies&q={q}&gl={country.upper()}"
+    return [
+        Movie(
+            title=f"→ Google Play : {query}",
+            description="Recherche Google Play (achat/location)",
+            stream_url=url,
+            source="Google Play",
+        )
+    ]

--- a/services/paid_itunes.py
+++ b/services/paid_itunes.py
@@ -1,0 +1,62 @@
+############################
+# Paid iTunes              #
+#                          #
+# Last update : 2025/08/25 #
+############################
+
+import requests
+from typing import List
+from .models import Movie
+
+
+def search(query: str, max_results: int = 20, country: str = "FR") -> List[Movie]:
+    """Search Apple iTunes Store for paid movie offers.
+
+    Parameters
+    ----------
+    query: str
+        Movie title to search for.
+    max_results: int, optional
+        Maximum number of results to return.
+    country: str, optional
+        Two-letter country code used by the API.
+    """
+    q = requests.utils.quote(query)
+    url = (
+        "https://itunes.apple.com/search"
+        f"?term={q}&media=movie&entity=movie&country={country}&limit={max_results}"
+    )
+    try:
+        resp = requests.get(url, timeout=10)
+        data = resp.json()
+    except Exception:
+        return []
+
+    out: List[Movie] = []
+    for it in data.get("results", [])[:max_results]:
+        title = it.get("trackName") or query
+        stream_url = it.get("trackViewUrl")
+        if not stream_url:
+            continue
+        description = it.get("longDescription") or it.get("shortDescription")
+        poster = it.get("artworkUrl100")
+        year = None
+        rel = it.get("releaseDate")
+        if rel:
+            try:
+                year = int(rel[:4])
+            except ValueError:
+                pass
+        out.append(
+            Movie(
+                title=title,
+                year=year,
+                description=description,
+                poster_url=poster,
+                stream_url=stream_url,
+                source="Apple iTunes",
+            )
+        )
+        if len(out) >= max_results:
+            break
+    return out

--- a/services/paid_rakuten.py
+++ b/services/paid_rakuten.py
@@ -1,0 +1,28 @@
+############################
+# Paid Rakuten             #
+#                          #
+# Last update : 2025/08/25 #
+############################
+
+import requests
+from typing import List
+from .models import Movie
+
+
+def search(query: str, max_results: int = 1, country: str = "FR") -> List[Movie]:
+    """Return a Rakuten TV search link.
+
+    No open Rakuten TV API is available without authentication,
+    thus we provide a search URL that points to the Rakuten TV catalog.
+    """
+    q = requests.utils.quote(query)
+    base = "www.rakuten.tv"
+    url = f"https://{base}/{country.lower()}/search?query={q}"
+    return [
+        Movie(
+            title=f"→ Rakuten TV : {query}",
+            description="Recherche Rakuten TV (achat/location)",
+            stream_url=url,
+            source="Rakuten TV",
+        )
+    ]


### PR DESCRIPTION
## Summary
- add new paid_itunes module using the iTunes Search API for movie purchase links
- add Google Play, Amazon Prime Video and Rakuten TV modules returning store search URLs
- merge results from dynamic and store-specific modules in paid_combo with URL deduplication

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af3c9163808326a08de5aedb47c682