### PR TITLE
feat: add movie runtime metadata

### DIFF
--- a/app.py
+++ b/app.py
@@ -191,6 +191,8 @@ def _card(movie, auto_translate: bool):
         meta = []
         if movie.year:
             meta.append(str(movie.year))
+        if movie.duration_minutes:
+            meta.append(f"{movie.duration_minutes} min")
         meta.append(movie.source)
         st.caption(" · ".join([x for x in meta if x]))
 

--- a/services/models.py
+++ b/services/models.py
@@ -13,6 +13,7 @@ from typing import Optional, Dict
 class Movie:
     title: str
     year: Optional[int] = None
+    duration_minutes: Optional[int] = None
     description: Optional[str] = None
     poster_url: Optional[str] = None
     stream_url: Optional[str] = None

--- a/services/search.py
+++ b/services/search.py
@@ -57,8 +57,11 @@ def run_search(
                 lst = fut.result()
                 if enrich_tmdb and key != "paid":
                     for m in lst:
+                        poster, runtime = tmdb.info_for(m.title, m.year)
                         if not m.poster_url:
-                            m.poster_url = tmdb.poster_for(m.title, m.year)
+                            m.poster_url = poster
+                        if runtime and not m.duration_minutes:
+                            m.duration_minutes = runtime
                 results[key] = lst
             except Exception:
                 results[key] = []


### PR DESCRIPTION
## Summary
- extend `Movie` model with optional `duration_minutes`
- fetch runtime from JustWatch and TMDB
- display runtime on result cards

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af40443a1083269dfb7c4d8f18be9d