### PR TITLE
Add price display for paid movie sources

### DIFF
--- a/app.py
+++ b/app.py
@@ -193,7 +193,13 @@ def _card(movie, auto_translate: bool):
             meta.append(str(movie.year))
         if movie.duration_minutes:
             meta.append(f"{movie.duration_minutes} min")
-        meta.append(movie.source)
+        if movie.source:
+            meta.append(movie.source)
+        if getattr(movie, "price", None):
+            mono = None
+            if isinstance(movie.extra, dict):
+                mono = movie.extra.get("monetization")
+            meta.append(f"{movie.price} {mono}".strip() if mono else movie.price)
         st.caption(" · ".join([x for x in meta if x]))
 
         # Description + traduction

--- a/services/models.py
+++ b/services/models.py
@@ -18,5 +18,6 @@ class Movie:
     poster_url: Optional[str] = None
     stream_url: Optional[str] = None
     download_url: Optional[str] = None
+    price: Optional[str] = None
     source: str = ""
     extra: Optional[Dict] = None


### PR DESCRIPTION
## Summary
- extend Movie dataclass with optional price field
- capture offer pricing in paid_dynamic and paid_itunes searches
- show price and monetization info next to provider in the UI

## Testing
- `pytest`
- `python -m py_compile app.py services/models.py services/paid_dynamic.py services/paid_itunes.py`


------
https://chatgpt.com/codex/tasks/task_e_68af412c49e48326ad162e7a89d6306c